### PR TITLE
Compute only metrics present in Characteristics Expressions

### DIFF
--- a/src/main/java/org/aksw/simba/lemming/mimicgraph/metricstorage/ConstantValueStorage.java
+++ b/src/main/java/org/aksw/simba/lemming/mimicgraph/metricstorage/ConstantValueStorage.java
@@ -239,7 +239,7 @@ public class ConstantValueStorage implements Serializable	{
 	 * @param lstMetrics - The list which contains all the input metrics.
 	 * @return List of metrics
 	 */
-	public List<SingleValueMetric> getMetrics(List<SingleValueMetric> lstMetrics){
+	public List<SingleValueMetric> getMetricsOfExpressions(List<SingleValueMetric> lstMetrics){
 	    List<SingleValueMetric> metrics = new ArrayList<>();// List which will contain metrics present in Expressions
 	    Set<Expression> constantExpressions = getConstantExpressions();
 	    Set<String> expressionsSet = new HashSet<>(); // Set to store atomic expression

--- a/src/main/java/org/aksw/simba/lemming/mimicgraph/metricstorage/ConstantValueStorage.java
+++ b/src/main/java/org/aksw/simba/lemming/mimicgraph/metricstorage/ConstantValueStorage.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import org.aksw.simba.lemming.ColouredGraph;
 import org.aksw.simba.lemming.algo.expression.Expression;
+import org.aksw.simba.lemming.algo.expression.ExpressionIterator;
 import org.aksw.simba.lemming.metrics.single.SingleValueMetric;
 import org.aksw.simba.lemming.tools.RefinementTest;
 import org.slf4j.Logger;
@@ -239,15 +240,26 @@ public class ConstantValueStorage implements Serializable	{
 	 * @return List of metrics
 	 */
 	public List<SingleValueMetric> getMetrics(List<SingleValueMetric> lstMetrics){
-	    List<SingleValueMetric> metrics = new ArrayList<>();
+	    List<SingleValueMetric> metrics = new ArrayList<>();// List which will contain metrics present in Expressions
 	    Set<Expression> constantExpressions = getConstantExpressions();
-	    for(SingleValueMetric metric: lstMetrics){
-	        for(Expression expression:constantExpressions) {
-	            if(expression.toString().contains(metric.getName())) {
-	                metrics.add(metric);
-	                break;
+	    Set<String> expressionsSet = new HashSet<>(); // Set to store atomic expression
+	    
+	    //Iterate over all expressions and add atomic expression in set.
+	    for(Expression expression:constantExpressions) {
+	        ExpressionIterator iterator = new ExpressionIterator(expression);
+	        while(iterator.hasNext()) {
+	            Expression subExpression = iterator.next();
+	            if(subExpression.isAtomic()) {
+	                expressionsSet.add(subExpression.toString());
 	            }
 	        }
+	    }
+	    
+	    //Iterate over input list of metrics and check which metrics are present in expressions
+	    for(SingleValueMetric metric: lstMetrics){
+	            if(expressionsSet.contains(metric.getName())) {
+	                metrics.add(metric);
+	           }
 	    }
 	    
 	    return metrics;

--- a/src/main/java/org/aksw/simba/lemming/mimicgraph/metricstorage/ConstantValueStorage.java
+++ b/src/main/java/org/aksw/simba/lemming/mimicgraph/metricstorage/ConstantValueStorage.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -231,5 +232,24 @@ public class ConstantValueStorage implements Serializable	{
 	
 	public static String generateGraphKey(ColouredGraph graph) {
 	    return graph.getGraph().getNumberOfVertices() + "-" + graph.getGraph().getNumberOfEdges();
+	}
+	
+	/** The method returns the list of metrics which are present in characteristics expressions.
+	 * @param lstMetrics - The list which contains all the input metrics.
+	 * @return List of metrics
+	 */
+	public List<SingleValueMetric> getMetrics(List<SingleValueMetric> lstMetrics){
+	    List<SingleValueMetric> metrics = new ArrayList<>();
+	    Set<Expression> constantExpressions = getConstantExpressions();
+	    for(SingleValueMetric metric: lstMetrics){
+	        for(Expression expression:constantExpressions) {
+	            if(expression.toString().contains(metric.getName())) {
+	                metrics.add(metric);
+	                break;
+	            }
+	        }
+	    }
+	    
+	    return metrics;
 	}
 }

--- a/src/main/java/org/aksw/simba/lemming/tools/GraphGenerationTest.java
+++ b/src/main/java/org/aksw/simba/lemming/tools/GraphGenerationTest.java
@@ -143,6 +143,7 @@ public class GraphGenerationTest {
         Loading metrics values and constant expressions 
         ----------------------------------------------------*/
         ConstantValueStorage valuesCarrier = new ConstantValueStorage(datasetPath);
+        metrics = valuesCarrier.getMetrics(metrics);
         if(!valuesCarrier.isComputableMetrics(metrics)){
         	LOGGER.error("The list of metrics has some metrics that are not existing in the precomputed metric values.");
         	LOGGER.warn("Please generate the file [value_store.val] again!");

--- a/src/main/java/org/aksw/simba/lemming/tools/GraphGenerationTest.java
+++ b/src/main/java/org/aksw/simba/lemming/tools/GraphGenerationTest.java
@@ -143,7 +143,7 @@ public class GraphGenerationTest {
         Loading metrics values and constant expressions 
         ----------------------------------------------------*/
         ConstantValueStorage valuesCarrier = new ConstantValueStorage(datasetPath);
-        metrics = valuesCarrier.getMetrics(metrics);
+        metrics = valuesCarrier.getMetricsOfExpressions(metrics);
         if(!valuesCarrier.isComputableMetrics(metrics)){
         	LOGGER.error("The list of metrics has some metrics that are not existing in the precomputed metric values.");
         	LOGGER.warn("Please generate the file [value_store.val] again!");


### PR DESCRIPTION
Created a method in ConstantValueStorage class. This method as an input takes a list of metrics. The list will contain all the metrics that are configured for the Lemming project. The method checks which metrics are part of the expression and returns an updated list that includes only metrics that are present in the expressions.